### PR TITLE
Feature for using calls like "VM_guest_metrics"

### DIFF
--- a/xenapi.php
+++ b/xenapi.php
@@ -56,8 +56,8 @@ class XenApi {
             $args = array();
         }
         $name = str_replace("__", "#", $name);
-		list($mod, $method) = explode('_', $name, 2);
-		$mod = str_replace("#", "_", $mod);
+	list($mod, $method) = explode('_', $name, 2);
+	$mod = str_replace("#", "_", $mod);
         
         $ret = $this->xenrpc_parseresponse($this->xenrpc_request($this->_url, 
                   $this->xenrpc_method($mod . '.' . $method, array_merge(array($this->_session_id), $args))));

--- a/xenapi.php
+++ b/xenapi.php
@@ -55,7 +55,10 @@ class XenApi {
         if (!is_array($args)) {
             $args = array();
         }
-        list($mod, $method) = explode('_', $name, 2);
+        $name = str_replace("__", "#", $name);
+		list($mod, $method) = explode('_', $name, 2);
+		$mod = str_replace("#", "_", $mod);
+        
         $ret = $this->xenrpc_parseresponse($this->xenrpc_request($this->_url, 
                   $this->xenrpc_method($mod . '.' . $method, array_merge(array($this->_session_id), $args))));
         return $ret;


### PR DESCRIPTION
When you call "VM_guest_metrics_get_networks" it's translated to "VM.guest_metrics_get_networks", which ends up with unknown method call. So with this patch, you can call "VM__guest__metrics_get_networks" (double underscores) and it will be translated correctly.
